### PR TITLE
Rename ibft to pbft

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -1,4 +1,4 @@
-package ibft
+package pbft
 
 import (
 	"context"
@@ -17,7 +17,7 @@ func TestTransition_ValidateState_Prepare(t *testing.T) {
 	t.Skip()
 
 	// we receive enough prepare messages to lock and commit the proposal
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	i := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 	i.setState(ValidateState)
 
 	i.emitMsg(&MessageReq{
@@ -59,7 +59,7 @@ func TestTransition_ValidateState_CommitFastTrack(t *testing.T) {
 
 	// we can directly receive the commit messages and fast track to the commit state
 	// even when we do not have yet the preprepare messages
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	i := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 
 	i.setState(ValidateState)
 	i.state.view = ViewMsg(1, 0)
@@ -99,7 +99,7 @@ func TestTransition_ValidateState_CommitFastTrack(t *testing.T) {
 func TestTransition_AcceptState_ToSyncState(t *testing.T) {
 	// we are in AcceptState and we are not in the validators list
 	// means that we have been removed as validator, move to sync state
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "")
+	i := newMockPbft(t, []string{"A", "B", "C", "D"}, "")
 	i.setState(AcceptState)
 
 	i.runCycle(context.Background())
@@ -123,7 +123,7 @@ func TestTransition_AcceptState_Proposer_Propose(t *testing.T) {
 	// 4. send a prepare message
 	// 5. move to ValidateState
 
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	i := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 	i.setState(AcceptState)
 
 	i.setProposal(&Proposal{
@@ -143,7 +143,7 @@ func TestTransition_AcceptState_Proposer_Propose(t *testing.T) {
 func TestTransition_AcceptState_Proposer_Locked(t *testing.T) {
 	// we are in AcceptState, we are the proposer but the value is locked.
 	// it needs to send the locked proposal again
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	i := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 	i.setState(AcceptState)
 
 	i.state.locked = true
@@ -163,7 +163,7 @@ func TestTransition_AcceptState_Proposer_Locked(t *testing.T) {
 }
 
 func TestTransition_AcceptState_Validator_VerifyCorrect(t *testing.T) {
-	i := newMockIbft(t, []string{"A", "B", "C"}, "B")
+	i := newMockPbft(t, []string{"A", "B", "C"}, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -187,7 +187,7 @@ func TestTransition_AcceptState_Validator_VerifyCorrect(t *testing.T) {
 func TestTransition_AcceptState_Validator_VerifyFails(t *testing.T) {
 	t.Skip("involves validation of hash that is not done yet")
 
-	i := newMockIbft(t, []string{"A", "B", "C"}, "B")
+	i := newMockPbft(t, []string{"A", "B", "C"}, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -209,7 +209,7 @@ func TestTransition_AcceptState_Validator_VerifyFails(t *testing.T) {
 }
 
 func TestTransition_AcceptState_Validator_ProposerInvalid(t *testing.T) {
-	i := newMockIbft(t, []string{"A", "B", "C"}, "B")
+	i := newMockPbft(t, []string{"A", "B", "C"}, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -235,7 +235,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 	// we are a validator and have a locked state in 'proposal1'.
 	// We receive an invalid proposal 'proposal2' with different data.
 
-	i := newMockIbft(t, []string{"A", "B", "C"}, "B")
+	i := newMockPbft(t, []string{"A", "B", "C"}, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -264,7 +264,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 }
 
 func TestTransition_AcceptState_Validator_LockCorrect(t *testing.T) {
-	i := newMockIbft(t, []string{"A", "B", "C"}, "B")
+	i := newMockPbft(t, []string{"A", "B", "C"}, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -292,7 +292,7 @@ func TestTransition_AcceptState_Validator_LockCorrect(t *testing.T) {
 }
 
 func TestTransition_RoundChangeState_CatchupRound(t *testing.T) {
-	m := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	m := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 	m.setState(RoundChangeState)
 
 	// new messages arrive with round number 2
@@ -328,7 +328,7 @@ func TestTransition_RoundChangeState_CatchupRound(t *testing.T) {
 }
 
 func TestTransition_RoundChangeState_Timeout(t *testing.T) {
-	m := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	m := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 
 	m.forceTimeout()
 	m.setState(RoundChangeState)
@@ -349,7 +349,7 @@ func TestTransition_RoundChangeState_Timeout(t *testing.T) {
 }
 
 func TestTransition_RoundChangeState_WeakCertificate(t *testing.T) {
-	m := newMockIbft(t, []string{"A", "B", "C", "D", "E", "F", "G"}, "A")
+	m := newMockPbft(t, []string{"A", "B", "C", "D", "E", "F", "G"}, "A")
 
 	m.setState(RoundChangeState)
 
@@ -385,7 +385,7 @@ func TestTransition_RoundChangeState_WeakCertificate(t *testing.T) {
 func TestTransition_RoundChangeState_ErrStartNewRound(t *testing.T) {
 	// if we start a round change because there was an error we start
 	// a new round right away
-	m := newMockIbft(t, []string{"A", "B"}, "A")
+	m := newMockPbft(t, []string{"A", "B"}, "A")
 	m.Close()
 
 	m.state.err = errVerificationFailed
@@ -404,7 +404,7 @@ func TestTransition_RoundChangeState_ErrStartNewRound(t *testing.T) {
 func TestTransition_RoundChangeState_StartNewRound(t *testing.T) {
 	// if we start round change due to a state timeout and we are on the
 	// correct sequence, we start a new round
-	m := newMockIbft(t, []string{"A", "B"}, "A")
+	m := newMockPbft(t, []string{"A", "B"}, "A")
 	m.Close()
 
 	m.setState(RoundChangeState)
@@ -421,7 +421,7 @@ func TestTransition_RoundChangeState_StartNewRound(t *testing.T) {
 func TestTransition_RoundChangeState_MaxRound(t *testing.T) {
 	// if we start round change due to a state timeout we try to catch up
 	// with the highest round seen.
-	m := newMockIbft(t, []string{"A", "B", "C"}, "A")
+	m := newMockPbft(t, []string{"A", "B", "C"}, "A")
 	m.Close()
 
 	m.addMessage(&MessageReq{
@@ -444,8 +444,8 @@ func TestTransition_RoundChangeState_MaxRound(t *testing.T) {
 	})
 }
 
-type mockIbft struct {
-	*Ibft
+type mockPbft struct {
+	*Pbft
 
 	t        *testing.T
 	pool     *testerAccountPool
@@ -455,15 +455,15 @@ type mockIbft struct {
 	cancelFn context.CancelFunc
 }
 
-func (m *mockIbft) emitMsg(msg *MessageReq) {
+func (m *mockPbft) emitMsg(msg *MessageReq) {
 	// convert the address from the address pool
 	// from := m.pool.get(string(msg.From)).Address()
 	// msg.From = from
 
-	m.Ibft.pushMessage(msg)
+	m.Pbft.pushMessage(msg)
 }
 
-func (m *mockIbft) addMessage(msg *MessageReq) {
+func (m *mockPbft) addMessage(msg *MessageReq) {
 	// convert the address from the address pool
 	//from := m.pool.get(string(msg.From)).Address()
 	//msg.From = from
@@ -471,18 +471,18 @@ func (m *mockIbft) addMessage(msg *MessageReq) {
 	m.state.addMessage(msg)
 }
 
-func (m *mockIbft) Gossip(msg *MessageReq) error {
+func (m *mockPbft) Gossip(msg *MessageReq) error {
 	m.respMsg = append(m.respMsg, msg)
 	return nil
 }
 
-func newMockIbft(t *testing.T, accounts []string, account string) *mockIbft {
+func newMockPbft(t *testing.T, accounts []string, account string) *mockPbft {
 	pool := newTesterAccountPool()
 	pool.add(accounts...)
 
 	validatorSet := newMockValidatorSet(accounts).(*valString)
 
-	m := &mockIbft{
+	m := &mockPbft{
 		t:        t,
 		pool:     pool,
 		respMsg:  []*MessageReq{},
@@ -511,27 +511,27 @@ func newMockIbft(t *testing.T, accounts []string, account string) *mockIbft {
 		loggerOutput = os.Stdout
 	}
 
-	// initialize ibft
-	m.Ibft = New(acct, m, WithLogger(log.New(loggerOutput, "", log.LstdFlags)))
-	m.Ibft.SetBackend(backend)
+	// initialize pbft
+	m.Pbft = New(acct, m, WithLogger(log.New(loggerOutput, "", log.LstdFlags)))
+	m.Pbft.SetBackend(backend)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
-	m.Ibft.ctx = ctx
+	m.Pbft.ctx = ctx
 	m.cancelFn = cancelFn
 
 	return m
 }
 
-func (i *mockIbft) Close() {
+func (i *mockPbft) Close() {
 	i.cancelFn()
 }
 
-func (i *mockIbft) setProposal(p *Proposal) {
+func (i *mockPbft) setProposal(p *Proposal) {
 	i.proposal = p
 }
 
 type expectResult struct {
-	state    IbftState
+	state    PbftState
 	sequence uint64
 	round    uint64
 	locked   bool
@@ -545,7 +545,7 @@ type expectResult struct {
 	outgoing uint64
 }
 
-func (m *mockIbft) expect(res expectResult) {
+func (m *mockPbft) expect(res expectResult) {
 	if sequence := m.state.view.Sequence; sequence != res.sequence {
 		m.t.Fatalf("incorrect sequence %d %d", sequence, res.sequence)
 	}
@@ -573,7 +573,7 @@ func (m *mockIbft) expect(res expectResult) {
 }
 
 type mockB struct {
-	mock *mockIbft
+	mock *mockPbft
 
 	validators *valString
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,15 +1,15 @@
 
-# E2E IBFT
+# E2E PBFT
 
 # Jaeger
 
-E2E tests uses OpenTracing to profile the execution of the IBFT state machine among the nodes in the cluster. It uses Jaeger to collect the tracing metrics, setup the Jaeger collector with:
+E2E tests uses OpenTracing to profile the execution of the PBFT state machine among the nodes in the cluster. It uses Jaeger to collect the tracing metrics, setup the Jaeger collector with:
 
 ```
 $ docker run --net=host jaegertracing/all-in-one:1.27
 ```
 
-You also need to run the OpenCollector to move data to Jaeger from the OpenTelemetry client in IBFT.
+You also need to run the OpenCollector to move data to Jaeger from the OpenTelemetry client in PBFT.
 
 ```
 $ docker run --net=host -v "${PWD}/otel-jaeger-config.yaml":/otel-local-config.yaml otel/opentelemetry-collector --config otel-local-config.yaml

--- a/e2e/e2e_node_drop_test.go
+++ b/e2e/e2e_node_drop_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestE2E_NodeDrop(t *testing.T) {
-	c := newIBFTCluster(t, "node_drop", "ptr", 5)
+	c := newPBFTCluster(t, "node_drop", "ptr", 5)
 	c.Start()
 
 	// wait for two heights and stop node 1

--- a/e2e/e2e_noissue_test.go
+++ b/e2e/e2e_noissue_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestE2E_NoIssue(t *testing.T) {
-	c := newIBFTCluster(t, "noissue", "noissue", 5, newRandomTransport(300*time.Millisecond))
+	c := newPBFTCluster(t, "noissue", "noissue", 5, newRandomTransport(300*time.Millisecond))
 	c.Start()
 
 	c.WaitForHeight(10, 1*time.Minute)

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -8,7 +8,7 @@ import (
 func TestE2E_Partition_OneMajority(t *testing.T) {
 	hook := newPartitionTransport(300 * time.Millisecond)
 
-	c := newIBFTCluster(t, "majority_partition", "prt", 5, hook)
+	c := newPBFTCluster(t, "majority_partition", "prt", 5, hook)
 	c.Start()
 
 	c.WaitForHeight(5, 1*time.Minute)

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,11 +1,11 @@
-module github.com/0xPolygon/ibft-consensus/e2e
+module github.com/0xPolygon/pbft-consensus/e2e
 
 go 1.17
 
-replace github.com/0xPolygon/ibft-consensus => ../
+replace github.com/0xPolygon/pbft-consensus => ../
 
 require (
-	github.com/0xPolygon/ibft-consensus v0.0.0-20211104133347-f8d6b7df3746
+	github.com/0xPolygon/pbft-consensus v0.0.0-20211104133347-f8d6b7df3746
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/0xPolygon/ibft-consensus
+module github.com/0xPolygon/pbft-consensus
 
 go 1.17
 

--- a/msg_queue.go
+++ b/msg_queue.go
@@ -1,11 +1,11 @@
-package ibft
+package pbft
 
 import (
 	"container/heap"
 	"sync"
 )
 
-// msgQueue defines the structure that holds message queues for different IBFT states
+// msgQueue defines the structure that holds message queues for different PBFT states
 type msgQueue struct {
 	// Heap implementation for the round change message queue
 	roundChangeStateQueue msgQueueImpl
@@ -30,12 +30,12 @@ func (m *msgQueue) pushMessage(task *msgTask) {
 }
 
 // readMessage reads the message from a message queue, based on the current state and view
-func (m *msgQueue) readMessage(state IbftState, current *View) *msgTask {
+func (m *msgQueue) readMessage(state PbftState, current *View) *msgTask {
 	msg, _ := m.readMessageWithDiscards(state, current)
 	return msg
 }
 
-func (m *msgQueue) readMessageWithDiscards(state IbftState, current *View) (*msgTask, []*msgTask) {
+func (m *msgQueue) readMessageWithDiscards(state PbftState, current *View) (*msgTask, []*msgTask) {
 	m.queueLock.Lock()
 	defer m.queueLock.Unlock()
 
@@ -80,7 +80,7 @@ func (m *msgQueue) readMessageWithDiscards(state IbftState, current *View) (*msg
 }
 
 // getQueue checks the passed in state, and returns the corresponding message queue
-func (m *msgQueue) getQueue(state IbftState) *msgQueueImpl {
+func (m *msgQueue) getQueue(state PbftState) *msgQueueImpl {
 	if state == RoundChangeState {
 		// round change
 		return &m.roundChangeStateQueue
@@ -102,8 +102,8 @@ func newMsgQueue() *msgQueue {
 	}
 }
 
-// msgToState converts the message type to an IbftState
-func msgToState(msg MsgType) IbftState {
+// msgToState converts the message type to an PbftState
+func msgToState(msg MsgType) PbftState {
 	if msg == MessageReq_RoundChange {
 		// round change
 		return RoundChangeState

--- a/msg_queue_test.go
+++ b/msg_queue_test.go
@@ -1,4 +1,4 @@
-package ibft
+package pbft
 
 import (
 	"testing"

--- a/state.go
+++ b/state.go
@@ -1,4 +1,4 @@
-package ibft
+package pbft
 
 import (
 	"fmt"
@@ -90,11 +90,11 @@ func ViewMsg(sequence, round uint64) *View {
 
 type NodeID string
 
-type IbftState uint32
+type PbftState uint32
 
-// Define the states in IBFT
+// Define the states in PBFT
 const (
-	AcceptState IbftState = iota
+	AcceptState PbftState = iota
 	RoundChangeState
 	ValidateState
 	CommitState
@@ -103,7 +103,7 @@ const (
 )
 
 // String returns the string representation of the passed in state
-func (i IbftState) String() string {
+func (i PbftState) String() string {
 	switch i {
 	case AcceptState:
 		return "AcceptState"
@@ -118,7 +118,7 @@ func (i IbftState) String() string {
 	case DoneState:
 		return "DoneState"
 	}
-	panic(fmt.Sprintf("BUG: Ibft state not found %d", i))
+	panic(fmt.Sprintf("BUG: Pbft state not found %d", i))
 }
 
 type Proposal struct {
@@ -129,7 +129,7 @@ type Proposal struct {
 	Time time.Time
 }
 
-// currentState defines the current state object in IBFT
+// currentState defines the current state object in PBFT
 type currentState struct {
 	// validators represent the current validator set
 	validators ValidatorSet
@@ -183,14 +183,14 @@ func (c *currentState) getCommittedSeals() [][]byte {
 }
 
 // getState returns the current state
-func (c *currentState) getState() IbftState {
+func (c *currentState) getState() PbftState {
 	stateAddr := (*uint64)(&c.state)
 
-	return IbftState(atomic.LoadUint64(stateAddr))
+	return PbftState(atomic.LoadUint64(stateAddr))
 }
 
 // setState sets the current state
-func (c *currentState) setState(s IbftState) {
+func (c *currentState) setState(s PbftState) {
 	stateAddr := (*uint64)(&c.state)
 
 	atomic.StoreUint64(stateAddr, uint64(s))

--- a/state_test.go
+++ b/state_test.go
@@ -1,4 +1,4 @@
-package ibft
+package pbft
 
 import (
 	"crypto/ecdsa"

--- a/transport.go
+++ b/transport.go
@@ -1,4 +1,4 @@
-package ibft
+package pbft
 
 // Transport is a generic interface for a gossip transport protocol
 type Transport interface {


### PR DESCRIPTION
In order to avoid confusions we should rename this package to pbft-consensus since it only implements the PBFT consensus algorithm and not the Clique blockchain validator selection.